### PR TITLE
23-fix-card-width-inconsistency

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -11,6 +11,7 @@
 
 .card {
     border-radius: var(--border-radius-sm);
+    width: 100%;
     max-width: 480px;
     background-color: var(--color-grey);
 }


### PR DESCRIPTION
added width:100% to card css to prevent cards with missing descriptions from being smaller size.